### PR TITLE
haku's commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 #Hardhat files
 cache
 artifacts
+contracts/types
 
 #misc
 .DS_Store

--- a/contracts/PaySplitter.sol
+++ b/contracts/PaySplitter.sol
@@ -35,10 +35,15 @@ contract PaySplitter is
         return super.supportsInterface(interfaceId);
     }
 
+    mapping(address => uint) amounts;
+    uint public totalAmounts;
+    address[] public payees;
+    bool public claimable;
+
     /**
      * @dev Initializing implementation.
-     * Creates an instance of `PaySplitter` where each address in `payees` is assigned a weight.
-     * All address in `payees` must be non-zero. There must be the one weight assigned per one payee.
+     * Creates an instance of `PaySplitter` where each address in `payees` is assigned a Amount.
+     * All address in `payees` must be non-zero. There must be the one Amount assigned per one payee.
      * There must be no duplicates in `payees`.
      */
     function __PaymentSplitter_init() internal onlyInitializing {
@@ -47,9 +52,115 @@ contract PaySplitter is
         /////////////////////////////////
     }
 
-    //////////////////////////////////////
-    ///// IMPLEMENT PAYSPLITTER HERE /////
-    //////////////////////////////////////
+    modifier onlyClaimable() {
+        require(claimable, "only Claimable");
+        _;
+    }
+
+    modifier onlyNotClaimable() {
+        require(!claimable, "only Not Claimable");
+        _;
+    }
+
+    function amount(address payee_) public view returns (uint) {
+        return amounts[payee_];
+    }
+
+    function addPayee(
+        address[] memory payees_,
+        uint[] memory amounts_
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) onlyNotClaimable {
+        require(
+            payees_.length == amounts_.length,
+            "PaySplitter: payees and amounts length mismatch"
+        );
+        for (uint i = 0; i < payees_.length; i++) {
+            require(
+                amount(payees_[i]) == 0,
+                "PaySplitter: account already has amounts"
+            );
+            require(
+                amounts_[i] > 0,
+                "PaySplitter: The value must be bigger than 0"
+            );
+            payees.push(payees_[i]);
+            totalAmounts += amounts_[i];
+            amounts[payees_[i]] = amounts_[i];
+        }
+    }
+
+    function updatePayee(
+        address[] memory payees_,
+        uint[] memory amounts_
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) onlyNotClaimable {
+        require(
+            payees_.length == amounts_.length,
+            "PaySplitter: payees and amounts length mismatch"
+        );
+        for (uint i = 0; i < payees_.length; i++) {
+            require(
+                amount(payees_[i]) != 0,
+                "PaySplitter: account doesn't have amounts"
+            );
+            totalAmounts -= amounts[payees_[i]];
+            totalAmounts += amounts_[i];
+            amounts[payees_[i]] = amounts_[i];
+        }
+    }
+
+    function deletePayeeInternal(address payees_) internal {
+        uint payeeAmount = amount(payees_);
+        require(payeeAmount > 0, "PaySplitter: account has no amounts");
+        totalAmounts -= payeeAmount;
+        amounts[payees_] = 0;
+    }
+
+    function deletePayee(
+        address[] memory payees_
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) onlyNotClaimable {
+        require(totalAmounts > 0, "PaySplitter: no payees");
+        for (uint i = 0; i < payees_.length; i++) {
+            deletePayeeInternal(payees_[i]);
+        }
+    }
+
+    function claim() external onlyClaimable {
+        uint sendAmount = amount(msg.sender);
+        deletePayeeInternal(msg.sender);
+        (bool sent, ) = msg.sender.call{value: sendAmount}("");
+        require(sent, "Failed to send Ether");
+    }
+
+    function cleanup() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        totalAmounts = 0;
+        claimable = false;
+        for (uint i = 0; i < payees.length; i++) {
+            amounts[payees[i]] = 0;
+        }
+        delete payees;
+        (bool sent, ) = msg.sender.call{value: address(this).balance}("");
+        require(sent, "Failed to send Ether");
+    }
+
+    function receiveEtherInternal() internal onlyNotClaimable {
+        require(msg.value > 0, "The value must be bigger than 0");
+        require(totalAmounts > 0, "You need one payee at least");
+        require(
+            address(this).balance <= totalAmounts,
+            "msg.value over totalAmounts"
+        );
+        if (address(this).balance == totalAmounts) {
+            claimable = true;
+        }
+    }
+
+    function deposit() external payable {
+        receiveEtherInternal();
+    }
+
+    fallback() external payable {
+        receiveEtherInternal();
+    }
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,22 +1,7 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { Contract, ContractFactory } from "ethers";
 import { ethers, upgrades } from "hardhat";
 
 const main = async () => {
-  const person_A = ethers.utils.getAddress(
-    "0x724C2F25Ca65fef27B2737901FB82D3b86BB6AE3",
-  );
-  const person_B = ethers.utils.getAddress(
-    "0x8e38C66278D6C3B83C5c38A9Da6b61e9E17656cd",
-  );
-  const person_C = ethers.utils.getAddress(
-    "0x412224535421f980b576880c05fE7E81Bf8a20d4",
-  );
-
-  const weight_A: number = 400;
-  const weight_B: number = 300;
-  const weight_C: number = 300;
-
   const PaySplitterFactory: ContractFactory = await ethers.getContractFactory(
     "PaySplitter",
   );

--- a/test/example.paysplit.test.ts
+++ b/test/example.paysplit.test.ts
@@ -14,34 +14,36 @@ describe("PaySplitter contract", function () {
   let addr1: SignerWithAddress;
   let addr2: SignerWithAddress;
   let addr3: SignerWithAddress;
-  let ownerWeight = 6;
-  let weight1 = 4;
-  let weight2 = 2;
-  let weight3 = 8;
-  let totalWeight: number;
+  let ownerAmount = 6;
+  let Amount1 = 4;
+  let Amount2 = 2;
+  let Amount3 = 8;
+  let totalAmount: number;
   let totalBalance: BigNumber;
   // `beforeEach` will run before each test, re-deploying the contract every
   // time. It receives a callback, which can be async.
 
   beforeEach(async function () {
     // Get the ContractFactory and Signers here.
-    totalWeight = 0;
+    totalAmount = 0;
     totalBalance = BigNumber.from("0");
     PaySplitterFactory = await ethers.getContractFactory("PaySplitter");
     [owner, addr1, addr2, addr3] = await ethers.getSigners();
     contract = await upgrades.deployProxy(PaySplitterFactory);
+    let tx = await contract.addPayee(
+      [owner.address, addr1.address],
+      [ownerAmount, Amount1],
+    );
+    await tx.wait();
   });
 
   describe("Deployment", function () {
-    it("Should set each weights correctly", async function () {
-      expect(await contract.weight(owner.address)).to.equal(ownerWeight);
-      expect(await contract.weight(addr1.address)).to.equal(weight1);
+    it("Should set each Amounts correctly", async function () {
+      expect(await contract.amount(owner.address)).to.equal(ownerAmount);
+      expect(await contract.amount(addr1.address)).to.equal(Amount1);
     });
-    it("Should set the right totalWeights", async function () {
-      expect(await contract.totalWeights()).to.equal(ownerWeight + weight1);
-    });
-    it("Should set the right address", async function () {
-      expect(await contract.payee(1)).to.equal(addr1.address);
+    it("Should set the right totalAmounts", async function () {
+      expect(await contract.totalAmounts()).to.equal(ownerAmount + Amount1);
     });
     it("Should set the right role", async function () {
       const adminRole = await contract.DEFAULT_ADMIN_ROLE();
@@ -51,64 +53,73 @@ describe("PaySplitter contract", function () {
 
   describe("Transactions common", function () {
     it("Should deposit properly", async function () {
-      let etherString = "1";
-      let wei: BigNumber = ethers.utils.parseEther(etherString);
-      totalBalance = totalBalance.add(wei);
-      let tx = await contract.deposit({
-        value: wei,
-      });
-      await tx.wait();
-      expect(await contract.totalBalance()).to.equal(totalBalance);
+      await expect(
+        contract.deposit({
+          value: 1,
+        }),
+      ).not.to.be.reverted;
+      await expect(
+        contract.deposit({
+          value: 9,
+        }),
+      ).not.to.be.reverted;
+      await expect(
+        contract.deposit({
+          value: 1,
+        }),
+      ).to.be.reverted;
+    });
 
-      totalWeight = ownerWeight + weight1;
-
-      wei = await calculateBalance(etherString, totalWeight, ownerWeight);
-      expect(await contract.balance(owner.address)).to.equal(wei);
-      wei = await calculateBalance(etherString, totalWeight, weight1);
-      expect(await contract.balance(addr1.address)).to.equal(wei);
+    it("Should fallback() properly", async function () {
+      await expect(
+        owner.sendTransaction({
+          to: contract.address,
+          value: 1,
+        }),
+      ).not.to.be.reverted;
+      await expect(
+        owner.sendTransaction({
+          to: contract.address,
+          value: 9,
+        }),
+      ).not.to.be.reverted;
+      await expect(
+        owner.sendTransaction({
+          to: contract.address,
+          value: 1,
+        }),
+      ).to.be.reverted;
     });
 
     it("Should add payees properly", async function () {
       let tx = await contract.addPayee(
         [addr2.address, addr3.address],
-        [weight2, weight3],
+        [Amount2, Amount3],
       );
       await tx.wait();
-      expect(await contract.totalWeights()).to.equal(
-        ownerWeight + weight1 + weight2 + weight3,
+      expect(await contract.totalAmounts()).to.equal(
+        ownerAmount + Amount1 + Amount2 + Amount3,
       );
-      expect(await contract.weight(addr2.address)).to.equal(weight2);
-      expect(await contract.weight(addr3.address)).to.equal(weight3);
-      expect(await contract.payee(2)).to.equal(addr2.address);
-      expect(await contract.payee(3)).to.equal(addr3.address);
+      expect(await contract.amount(addr2.address)).to.equal(Amount2);
+      expect(await contract.amount(addr3.address)).to.equal(Amount3);
     });
 
     it("Should delete a payee properly", async function () {
-      let tx = await contract.deletePayee(addr1.address);
+      let tx = await contract.deletePayee([addr1.address]);
       await tx.wait();
-      expect(await contract.totalWeights()).to.equal(ownerWeight);
-      expect(await contract.balance(addr1.address)).to.equal(0);
-      expect(await contract.weight(addr1.address)).to.equal(0);
+      expect(await contract.totalAmounts()).to.equal(ownerAmount);
+      expect(await contract.amount(addr1.address)).to.equal(0);
     });
 
-    it("Should release properly", async function () {
-      let etherString = "1";
-      let wei: BigNumber = ethers.utils.parseEther(etherString);
-      let tx = await contract.deposit({
-        value: wei,
-      });
-      let receipt = await tx.wait();
-      totalBalance = totalBalance.add(wei);
-      totalWeight = ownerWeight + weight1;
-
-      wei = await calculateBalance(etherString, totalWeight, ownerWeight);
-      tx = await contract.release();
-      receipt = await tx.wait();
-      expect(await contract.balance(owner.address)).to.equal(0);
-
-      expect(await contract.totalBalance()).to.equal(
-        await totalBalance.sub(wei),
-      );
+    it("Should claim properly", async function () {
+      await expect(
+        owner.sendTransaction({
+          to: contract.address,
+          value: 10,
+        }),
+      ).not.to.be.reverted;
+      await expect(contract.claim()).not.to.be.reverted;
+      await expect(contract.claim()).to.be.reverted;
     });
   });
 
@@ -116,7 +127,8 @@ describe("PaySplitter contract", function () {
     it("Should fail if sender doesn't send enough eth", async function () {
       let etherString = "0";
       await expect(
-        contract.deposit({
+        owner.sendTransaction({
+          to: contract.address,
           value: ethers.utils.parseEther(etherString),
         }),
       ).to.be.revertedWith("The value must be bigger than 0");
@@ -128,16 +140,23 @@ describe("PaySplitter contract", function () {
       ).to.be.revertedWith("The value must be bigger than 0");
     });
     it("Should fail if there is no payees when deposit", async function () {
-      let tx = await contract.deletePayee(owner.address);
-      await tx.wait();
-      tx = await contract.deletePayee(addr1.address);
+      let tx = await contract.deletePayee([owner.address, addr1.address]);
       await tx.wait();
       let etherString = "1";
       await expect(
-        contract.deposit({
+        owner.sendTransaction({
+          to: contract.address,
           value: ethers.utils.parseEther(etherString),
         }),
       ).to.be.revertedWith("You need one payee at least");
+    });
+    it("Should fail if deposit value over amounts", async function () {
+      await expect(
+        owner.sendTransaction({
+          to: contract.address,
+          value: 11,
+        }),
+      ).to.be.revertedWith("msg.value over totalAmounts");
     });
   });
 
@@ -145,7 +164,7 @@ describe("PaySplitter contract", function () {
     it("Should fail if non admin tries to do addPayee", async function () {
       let adminHexString: string = await contract.DEFAULT_ADMIN_ROLE();
       let errMsg = `AccessControl: account ${String(
-        ethers.utils.getAddress(addr1.address),
+        addr1.address.toLowerCase(),
       )} is missing role ${adminHexString}`;
       await expect(
         contract
@@ -156,34 +175,26 @@ describe("PaySplitter contract", function () {
     it("Should fail if admin tries to do addPayee with diffrent length args", async function () {
       await expect(
         contract.addPayee([addr2.address, addr3.address], [3, 4, 5]),
-      ).to.be.revertedWith("PaySplitter: payees and weights length mismatch");
+      ).to.be.revertedWith("PaySplitter: payees and amounts length mismatch");
       await expect(
         contract.addPayee(
           [addr1.address, addr2.address, addr3.address],
           [3, 4],
         ),
-      ).to.be.revertedWith("PaySplitter: payees and weights length mismatch");
+      ).to.be.revertedWith("PaySplitter: payees and amounts length mismatch");
     });
     it("Should fail if admin tries to do addPayee with the address already added", async function () {
       await expect(
         contract.addPayee([addr2.address, addr1.address], [3, 4]),
-      ).to.be.revertedWith("PaySplitter: account already has weights");
+      ).to.be.revertedWith("PaySplitter: account already has amounts");
       await expect(contract.addPayee([owner.address], [4])).to.be.revertedWith(
-        "PaySplitter: account already has weights",
+        "PaySplitter: account already has amounts",
       );
       let tx = await contract.addPayee([addr2.address, addr3.address], [3, 4]);
       await tx.wait();
       await expect(contract.addPayee([addr3.address], [4])).to.be.revertedWith(
-        "PaySplitter: account already has weights",
+        "PaySplitter: account already has amounts",
       );
-    });
-    it("Should fail if weights are not right", async function () {
-      await expect(
-        contract.addPayee([addr2.address, addr3.address], [0, 4]),
-      ).to.be.revertedWith("PaySplitter: 0 < weight <= 10000");
-      await expect(
-        contract.addPayee([addr2.address], [10001]),
-      ).to.be.revertedWith("PaySplitter: 0 < weight <= 10000");
     });
   });
 
@@ -191,111 +202,18 @@ describe("PaySplitter contract", function () {
     it("Should fail if non admin tries to do deletePayee", async function () {
       let adminHexString: string = await contract.DEFAULT_ADMIN_ROLE();
       let errMsg = `AccessControl: account ${String(
-        ethers.utils.getAddress(addr1.address),
+        addr1.address.toLowerCase(),
       )} is missing role ${adminHexString}`;
       await expect(
-        contract.connect(addr1).deletePayee(addr1.address),
+        contract.connect(addr1).deletePayee([addr1.address]),
       ).to.be.revertedWith(errMsg);
     });
 
     it("Should fail if there is no payees when deletePayee", async function () {
-      let tx = await contract.deletePayee(owner.address);
+      let tx = await contract.deletePayee([owner.address, addr1.address]);
       await tx.wait();
-      tx = await contract.deletePayee(addr1.address);
-      await tx.wait();
-      await expect(contract.deletePayee(owner.address)).to.be.revertedWith(
+      await expect(contract.deletePayee([owner.address])).to.be.revertedWith(
         "PaySplitter: no payees",
-      );
-    });
-
-    it("Should fail if there is still balance when deletePayee", async function () {
-      let etherString = "1";
-      let wei: BigNumber = ethers.utils.parseEther(etherString);
-      let tx = await contract.deposit({
-        value: wei,
-      });
-      await tx.wait();
-      await expect(contract.deletePayee(owner.address)).to.be.revertedWith(
-        "PaySplitter: There is balance in the account",
-      );
-    });
-
-    it("Should fail if there is not the payees when deletePayee", async function () {
-      let tx = await contract.deletePayee(addr1.address);
-      await tx.wait();
-      await expect(contract.deletePayee(addr1.address)).to.be.revertedWith(
-        "PaySplitter: account has no weights",
-      );
-    });
-  });
-
-  describe("Transactions release revert", function () {
-    it("Should fail if non payee tries to release", async function () {
-      await expect(contract.connect(addr2).release()).to.be.revertedWith(
-        "PaySplitter: account has no weights",
-      );
-    });
-    it("Should fail if payee doesn't have balance", async function () {
-      let tx = await contract.deposit({
-        value: ethers.utils.parseEther("1"),
-      });
-      await tx.wait();
-      tx = await contract.connect(addr1).release();
-      await tx.wait();
-      await expect(contract.connect(addr1).release()).to.be.revertedWith(
-        "PaySplitter: account is not due payment",
-      );
-    });
-  });
-
-  describe("Transactions various cases", function () {
-    it("various case 1 ", async function () {
-      let etherString = "1";
-      let wei: BigNumber = ethers.utils.parseEther(etherString);
-      let tx = await contract.deposit({
-        value: wei,
-      });
-      await tx.wait();
-      expect(await contract.totalBalance()).to.equal(wei);
-
-      totalWeight = ownerWeight + weight1;
-
-      wei = await calculateBalance(etherString, totalWeight, ownerWeight);
-      expect(await contract.balance(owner.address)).to.equal(wei);
-      let wei1: BigNumber = await calculateBalance(
-        etherString,
-        totalWeight,
-        weight1,
-      );
-
-      tx = await contract.addPayee(
-        [addr2.address, addr3.address],
-        [weight2, weight3],
-      );
-      await tx.wait();
-      totalWeight += weight2 + weight3;
-
-      expect(await contract.totalWeights()).to.equal(totalWeight);
-
-      tx = await contract.release();
-      await tx.wait();
-
-      expect(await contract.balance(owner.address)).to.equal(0);
-
-      await addr1.sendTransaction({
-        to: contract.address,
-        value: ethers.utils.parseEther(etherString),
-      });
-
-      wei = await calculateBalance(etherString, totalWeight, ownerWeight);
-      expect(await contract.balance(owner.address)).to.equal(wei);
-      wei = await calculateBalance(etherString, totalWeight, weight1);
-      expect(await contract.balance(addr1.address)).to.equal(
-        await wei.add(wei1),
-      );
-
-      await expect(contract.deletePayee(owner.address)).to.be.revertedWith(
-        "PaySplitter: There is balance in the account",
       );
     });
   });


### PR DESCRIPTION
# 全体設計/概要
1つのコントラクトで1つの支払いと分配ができる
必要な分配金がプールされるまで誰も引き出せず、諸事情によりOwnerがリセットするまでプール資金は抜けない
（分配対象者が平等のタイミングで収益を受け取れることを保証する）

## 各変数の説明

- `amounts`
  - 各分配対象者が受け取れる金額
- `totalAmounts`
  - 必要な分配金の総量
- `payees`
  - 分配対象者のリスト
- `claimable`
  - claim可能かどうかのフラグ

## 各関数の説明

- `amount(address payee_)`
  - payee_の受け取れる金額を返す
- `addPayee(address[] memory payees_, uint[] memory amounts_)`
  - 分配対象者を追加する
  - 既存分配対象者は追加できず、amounts_は0より大きくなければいけない
- `updatePayee(address[] memory payees_, uint[] memory amounts_)`
  - 分配対象者の受け取れる金額を変更する
  - 既存分配対象者のみが対象
- `deletePayeeInternal(address payees_)`
  - 分配対象者を削除するInternal関数
  - 既存分配対象者のみが対象
- `deletePayee(address[] memory payees_)`
  - 分配対象者を削除する
  - 既存分配対象者が存在する必要がある
- `claim()`
  - msg.senderに受け取れる金額を送信する
  - 分配対象者のみが対象
- `cleanup()`
  - 分配対象者や分配金などすべてをリセットする
  - オーナーのみが実行できる
- `receiveEtherInternal()`
  - Etherを受け取るInternal関数
- `deposit()とfallback`
  - Etherを受け取るために呼ばれる

## その他特筆事項
claimableフラグによってできる操作・できない操作が存在する
各関数のmodifierのonlyClaimable, onlyNotClaimableを参照
分配対象者が存在し、必要な分配金の総量がコントラクトに溜まったときclaimableになる
claimableになると分配対象者の追加・削除などができなくなり、分配対象者がclaimできるようになる
状態をリセットできるのはownerのみ
